### PR TITLE
Initialize study manager project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+studymanager.db
+config.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# testing_chatgpt_codex
+# Study Manager
 
-this repo is just for testing how chatGPT's new "codex" works
+A simple CLI tool to manage study notes. Notes can include text or file attachments and support tagging by course and chapter. Each note has a `max_cooldown` which determines the number of days until it is due again, skipping configured off days.
+
+## Features
+- Create new notes
+- Fetch due notes
+- Increase or reset the cooldown of a note
+
+Run `python -m studymanager.cli --help` for usage instructions.
+

--- a/studymanager/__init__.py
+++ b/studymanager/__init__.py
@@ -1,0 +1,2 @@
+"""Study Manager package."""
+

--- a/studymanager/cli.py
+++ b/studymanager/cli.py
@@ -1,0 +1,76 @@
+import argparse
+from . import db
+
+
+def cmd_init(args):
+    db.init_db()
+    print('Database initialized.')
+
+
+def cmd_add(args):
+    db.add_note(content=args.content, file_path=args.file, question=args.question,
+                question_file=args.question_file, course=args.course,
+                chapter=args.chapter, max_cooldown=args.max_cooldown)
+    print('Note added.')
+
+
+def cmd_due(args):
+    notes = db.fetch_due_notes()
+    for n in notes:
+        print(n)
+
+
+def cmd_inc(args):
+    conn_cool = args.increase
+    db.update_cooldown(args.note_id, conn_cool)
+    print(f'Cooldown updated to {conn_cool}.')
+
+
+def cmd_reset(args):
+    db.update_cooldown(args.note_id, 1)
+    print('Cooldown reset to 1.')
+
+
+def build_parser():
+    p = argparse.ArgumentParser(description='Study Manager CLI')
+    sub = p.add_subparsers(dest='command')
+
+    init_p = sub.add_parser('init', help='Initialize database')
+    init_p.set_defaults(func=cmd_init)
+
+    add_p = sub.add_parser('add', help='Add new note')
+    add_p.add_argument('--content')
+    add_p.add_argument('--file')
+    add_p.add_argument('--question')
+    add_p.add_argument('--question-file')
+    add_p.add_argument('--course')
+    add_p.add_argument('--chapter')
+    add_p.add_argument('--max-cooldown', type=int, default=1)
+    add_p.set_defaults(func=cmd_add)
+
+    due_p = sub.add_parser('due', help='Show due notes')
+    due_p.set_defaults(func=cmd_due)
+
+    inc_p = sub.add_parser('inc', help='Increase cooldown by 1')
+    inc_p.add_argument('note_id', type=int)
+    inc_p.add_argument('increase', type=int, nargs='?', default=None)
+    inc_p.set_defaults(func=cmd_inc)
+
+    reset_p = sub.add_parser('reset', help='Reset cooldown to 1')
+    reset_p.add_argument('note_id', type=int)
+    reset_p.set_defaults(func=cmd_reset)
+
+    return p
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()
+

--- a/studymanager/config.py
+++ b/studymanager/config.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+CONFIG_FILE = Path('config.json')
+
+def load_config():
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {'off_days': []}
+
+def save_config(config):
+    with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+        json.dump(config, f, indent=2)
+

--- a/studymanager/db.py
+++ b/studymanager/db.py
@@ -1,0 +1,79 @@
+import sqlite3
+from pathlib import Path
+from datetime import date, timedelta
+from .config import load_config
+
+DB_FILE = Path('studymanager.db')
+
+SCHEMA = '''
+CREATE TABLE IF NOT EXISTS notes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT,
+    file_path TEXT,
+    question TEXT,
+    question_file TEXT,
+    course TEXT,
+    chapter TEXT,
+    max_cooldown INTEGER,
+    due_date DATE,
+    created_at DATE
+);
+'''
+
+def connect():
+    conn = sqlite3.connect(DB_FILE)
+    return conn
+
+
+def init_db():
+    conn = connect()
+    conn.execute(SCHEMA)
+    conn.commit()
+    conn.close()
+
+
+def compute_due_date(start: date, cooldown: int, off_days=None) -> date:
+    if off_days is None:
+        off_days = []
+    current = start
+    added = 0
+    while added < cooldown:
+        current += timedelta(days=1)
+        if current.weekday() not in off_days:
+            added += 1
+    return current
+
+
+def add_note(content=None, file_path=None, question=None, question_file=None,
+             course=None, chapter=None, max_cooldown=1):
+    cfg = load_config()
+    off_days = cfg.get('off_days', [])
+    due = compute_due_date(date.today(), max_cooldown, off_days)
+    conn = connect()
+    conn.execute(
+        'INSERT INTO notes (content, file_path, question, question_file, course, chapter, max_cooldown, due_date, created_at) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        (content, file_path, question, question_file, course, chapter, max_cooldown, due.isoformat(), date.today().isoformat())
+    )
+    conn.commit()
+    conn.close()
+
+
+def fetch_due_notes():
+    conn = connect()
+    cur = conn.execute('SELECT * FROM notes WHERE due_date <= ?', (date.today().isoformat(),))
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def update_cooldown(note_id: int, new_cooldown: int):
+    cfg = load_config()
+    off_days = cfg.get('off_days', [])
+    new_due = compute_due_date(date.today(), new_cooldown, off_days)
+    conn = connect()
+    conn.execute('UPDATE notes SET max_cooldown = ?, due_date = ? WHERE id = ?',
+                 (new_cooldown, new_due.isoformat(), note_id))
+    conn.commit()
+    conn.close()
+


### PR DESCRIPTION
## Summary
- start study manager package
- support config file for off-days
- handle database with notes and cooldown scheduling
- implement CLI to create and manage notes
- document usage in README

## Testing
- `python3 -m studymanager.cli --help`
- `python3 -m studymanager.cli init`
- `python3 -m studymanager.cli add --content "First note" --course Math --chapter 1`
- `python3 -m studymanager.cli due`
- `python3 -m studymanager.cli inc 1 2`
- `python3 -m studymanager.cli reset 1`


------
https://chatgpt.com/codex/tasks/task_e_685018b056b08333bdcb2100d8f289a1